### PR TITLE
Change module name to comply with packagist name

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,8 +31,8 @@ jobs:
       - name: M2 Integration Tests with Magento 2 (Php7.4)
         uses: extdn/github-actions-m2/magento-integration-tests/7.4@master
         with:
-          module_name: JBrada_AdminOrderProductLinks
-          composer_name: jbrada/module-admin-order-product-links
+          module_name: JBrada_AdminDocumentProductLinks
+          composer_name: jbrada/module-admin-document-product-links
           composer_version: 2
           ce_version: '2.4.3-p1'
           magento_pre_install_script: .github/workflows/integration/pre-install.sh

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: extdn/github-actions-m2/magento-phpstan@master
         with:
-          composer_name: jbrada/module-admin-order-product-links
+          composer_name: jbrada/module-admin-document-product-links
           magento_pre_install_script: .github/workflows/static-analysis/phpstan-pre-install.sh
 
   coding-standard:

--- a/Api/IsProductExistingInterface.php
+++ b/Api/IsProductExistingInterface.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace JBrada\AdminOrderProductLinks\Api;
+namespace JBrada\AdminDocumentProductLinks\Api;
 
 interface IsProductExistingInterface
 {

--- a/Model/Query/IsProductExisting.php
+++ b/Model/Query/IsProductExisting.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace JBrada\AdminOrderProductLinks\Model\Query;
+namespace JBrada\AdminDocumentProductLinks\Model\Query;
 
-use JBrada\AdminOrderProductLinks\Api\IsProductExistingInterface;
+use JBrada\AdminDocumentProductLinks\Api\IsProductExistingInterface;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 
 class IsProductExisting implements IsProductExistingInterface

--- a/Plugin/Block/Adminhtml/Items/Column/Name/LinkToProductInAdmin.php
+++ b/Plugin/Block/Adminhtml/Items/Column/Name/LinkToProductInAdmin.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace JBrada\AdminOrderProductLinks\Plugin\Block\Adminhtml\Items\Column\Name;
+namespace JBrada\AdminDocumentProductLinks\Plugin\Block\Adminhtml\Items\Column\Name;
 
-use JBrada\AdminOrderProductLinks\Model\Query\IsProductExisting;
+use JBrada\AdminDocumentProductLinks\Model\Query\IsProductExisting;
 use Magento\Sales\Block\Adminhtml\Items\Column\Name;
 
 class LinkToProductInAdmin

--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@
 <br />
 <div align="center">
 
-<h3 align="center">JBrada/AdminOrderProductLinks</h3>
+<h3 align="center">JBrada/AdminDocumentProductLinks</h3>
 
   <p align="center">
     A simple module adds a navigation link between order, shipment, invoice and credit memo items and its related products.
     <br />
     <br />
-    <a href="https://github.com/jbrada/module-admin-order-product-links/issues">Report Bug</a>
+    <a href="https://github.com/jbrada/module-admin-document-product-links/issues">Report Bug</a>
     ·
-    <a href="https://github.com/jbrada/module-admin-order-product-links/issues">Request Feature</a>
+    <a href="https://github.com/jbrada/module-admin-document-product-links/issues">Request Feature</a>
   </p>
 </div>
 
 ## About The Project
 
-[![ScreenShot][product-screenshot]](https://github.com/jbrada/module-admin-order-product-links)
+[![ScreenShot][product-screenshot]](https://github.com/jbrada/module-admin-document-product-links)
 
 Just a link between Order related entities and product :upside_down_face:
 
@@ -38,12 +38,12 @@ Just a link between Order related entities and product :upside_down_face:
 
 1. (Optional if you are still using Composer 1)
     ```sh
-    composer config repositories.jbrada/module-admin-order-product-links vcs https://github.com/jbrada/module-admin-order-product-links
+    composer config repositories.jbrada/module-admin-document-product-links vcs https://github.com/jbrada/module-admin-document-product-links
     ```
 
 2. Require package
    ```sh
-   composer require jbrada/module-admin-order-product-links
+   composer require jbrada/module-admin-document-product-links
    ```
 3. Setup:upgrade
    ```sh
@@ -64,23 +64,23 @@ Distributed under the MIT License. See `LICENSE` for more information.
 
 Jiří Brada - jiri@jbrada.cz
 
-Project Link: [https://github.com/jbrada/module-admin-order-product-links](https://github.com/jbrada/module-admin-order-product-links)
+Project Link: [https://github.com/jbrada/module-admin-document-product-links](https://github.com/jbrada/module-admin-document-product-links)
 
 
 
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
-[contributors-shield]: https://img.shields.io/github/contributors/jbrada/module-admin-order-product-links.svg?style=for-the-badge
-[contributors-url]: https://github.com/jbrada/module-admin-order-product-links/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/jbrada/module-admin-order-product-links.svg?style=for-the-badge
-[forks-url]: https://github.com/jbrada/module-admin-order-product-links/network/members
-[stars-shield]: https://img.shields.io/github/stars/jbrada/module-admin-order-product-links.svg?style=for-the-badge
-[stars-url]: https://github.com/jbrada/module-admin-order-product-links/stargazers
-[issues-shield]: https://img.shields.io/github/issues/jbrada/module-admin-order-product-links.svg?style=for-the-badge
-[issues-url]: https://github.com/jbrada/module-admin-order-product-links/issues
-[license-shield]: https://img.shields.io/github/license/jbrada/module-admin-order-product-links.svg?style=for-the-badge
-[license-url]: https://github.com/jbrada/module-admin-order-product-links/blob/main/LICENSE.md
+[contributors-shield]: https://img.shields.io/github/contributors/jbrada/module-admin-document-product-links.svg?style=for-the-badge
+[contributors-url]: https://github.com/jbrada/module-admin-document-product-links/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/jbrada/module-admin-document-product-links.svg?style=for-the-badge
+[forks-url]: https://github.com/jbrada/module-admin-document-product-links/network/members
+[stars-shield]: https://img.shields.io/github/stars/jbrada/module-admin-document-product-links.svg?style=for-the-badge
+[stars-url]: https://github.com/jbrada/module-admin-document-product-links/stargazers
+[issues-shield]: https://img.shields.io/github/issues/jbrada/module-admin-document-product-links.svg?style=for-the-badge
+[issues-url]: https://github.com/jbrada/module-admin-document-product-links/issues
+[license-shield]: https://img.shields.io/github/license/jbrada/module-admin-document-product-links.svg?style=for-the-badge
+[license-url]: https://github.com/jbrada/module-admin-document-product-links/blob/main/LICENSE.md
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 [linkedin-url]: https://linkedin.com/in/jbrada
 [product-screenshot]: images/screenshot.png

--- a/Test/Integration/Model/Query/IsProductExistingTest.php
+++ b/Test/Integration/Model/Query/IsProductExistingTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace JBrada\AdminOrderProductLinks\Test\Integration\Model\Query;
+namespace JBrada\AdminDocumentProductLinks\Test\Integration\Model\Query;
 
-use JBrada\AdminOrderProductLinks\Model\Query\IsProductExisting;
+use JBrada\AdminDocumentProductLinks\Model\Query\IsProductExisting;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
 use TddWizard\Fixtures\Catalog\ProductBuilder;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jbrada/module-admin-order-product-links",
+    "name": "jbrada/module-admin-document-product-links",
     "type": "magento2-module",
     "description": "Module enables link from admin items list to product edit page.",
     "license":"MIT",
@@ -29,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-            "JBrada\\AdminOrderProductLinks\\": ""
+            "JBrada\\AdminDocumentProductLinks\\": ""
         },
         "files": [
             "registration.php"

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -3,6 +3,6 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Sales\Block\Adminhtml\Items\Column\Name">
         <plugin name="jbrada_link_to_product_in_admin_column_name"
-                type="JBrada\AdminOrderProductLinks\Plugin\Block\Adminhtml\Items\Column\Name\LinkToProductInAdmin"/>
+                type="JBrada\AdminDocumentProductLinks\Plugin\Block\Adminhtml\Items\Column\Name\LinkToProductInAdmin"/>
     </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="JBrada_AdminOrderProductLinks">
+    <module name="JBrada_AdminDocumentProductLinks">
         <sequence>
             <module name="Magento_Sales" />
         </sequence>

--- a/registration.php
+++ b/registration.php
@@ -5,6 +5,6 @@ use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(
     ComponentRegistrar::MODULE,
-    'JBrada_AdminOrderProductLinks',
+    'JBrada_AdminDocumentProductLinks',
     __DIR__
 );


### PR DESCRIPTION
There is an incompatibility between Packagist package name and GIthub package name here.
The purpose of this PR is to unite naming across platform servies.